### PR TITLE
Remove link to /repl for now

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,6 @@
 // Continuously updated test262 results are available at <a href="test262">/test262</a>.
 // Continuously updated Wasm results are available at <a href="wasm">/wasm</a>.
 //
-// If you wish to play with LibJS in your browser, head over to <a href="repl">/repl</a>.
-//
 // If you're a Ladybird contributor and want to change something
 // here, open a PR in <a href="https://github.com/LadybirdBrowser/libjs-website">this repository</a>.</span></code></pre>
   </body>


### PR DESCRIPTION
Because the WASM build of LibJS no longer exists.